### PR TITLE
Modern Skoice 3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.clementraynaud</groupId>
     <artifactId>Skoice</artifactId>
-    <version>2.0.3</version>
+    <version>2.0.2</version>
     <packaging>jar</packaging>
 
     <name>Skoice</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.clementraynaud</groupId>
     <artifactId>Skoice</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <packaging>jar</packaging>
 
     <name>Skoice</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.clementraynaud</groupId>
     <artifactId>Skoice</artifactId>
-    <version>2.0.2</version>
+    <version>2.1</version>
     <packaging>jar</packaging>
 
     <name>Skoice</name>

--- a/src/main/java/net/clementraynaud/Skoice.java
+++ b/src/main/java/net/clementraynaud/Skoice.java
@@ -103,7 +103,9 @@ public class Skoice extends JavaPlugin {
 
             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(new URL("https://raw.githubusercontent.com/carlodrift/skoice/main/version").openStream()));
             String spigotVersion = bufferedReader.readLine();
-            if (!skoiceFileVersion.equals(spigotVersion)) {
+
+            int nm = isUpdateAvailable(skoiceFileVersion, spigotVersion);
+            if (nm>0) {
                 getLogger().warning((Object) ChatColor.RED + "You are using an outdated version!");
                 getLogger().warning("Latest version: " + (Object) ChatColor.GREEN + spigotVersion + (Object) ChatColor.YELLOW + ". You are on version: " + ChatColor.RED + skoiceFileVersion + (Object) ChatColor.YELLOW + ".");
                 getLogger().warning("Update here: " + (Object) ChatColor.AQUA + "https://www.spigotmc.org/resources/skoice-proximity-voice-chat.82861/");
@@ -113,6 +115,7 @@ public class Skoice extends JavaPlugin {
         } catch (IOException e) {
             //getLogger().severe("Unable to check for updates. Error: " + e.getMessage());
 //                checkVersion();
+            getLogger().warning("Had a error checking the version:\n"+e.getStackTrace()+"\nGoing to continue anyway");
         }
 
     }

--- a/src/main/java/net/clementraynaud/Skoice.java
+++ b/src/main/java/net/clementraynaud/Skoice.java
@@ -58,10 +58,12 @@ public class Skoice extends JavaPlugin {
         getConfig().options().copyDefaults();
         createConfig();
         getLogger().info("Plugin enabled!");
-        if(playerData.getString("token").equals("")){
+        if(playerData.getString("token").equals("") || playerData.getString("token") == null){
             getLogger().severe(ChatColor.RED + "No bot token, edit the data.yml to add token");
-        } else if(playerData.getString("mainVoiceChannelID").equals("")){
+        } else if(playerData.getString("mainVoiceChannelID").equals("") || playerData.getString("mainVoiceChannelID") == null){
             getLogger().severe(ChatColor.RED + "No bot mainVoiceChannelID, edit the data.yml to add mainVoiceChannelID");
+        } else if(playerData.getString("categoryID").equals("") || playerData.getString("categoryID")==null){
+            getLogger().severe(ChatColor.RED + "No bot categoryID, edit the data.yml to add categoryID");
         } else if(playerData.getString("distance")==null) {
             getLogger().severe(ChatColor.RED + "No distance config found, make sure you add the 'distance' from data https://github.com/carlodrift/skoice/blob/dev/src/main/resources/data.yml");
         }else if(playerData.getString("checkVersion")==null) {

--- a/src/main/java/net/clementraynaud/Skoice.java
+++ b/src/main/java/net/clementraynaud/Skoice.java
@@ -58,61 +58,62 @@ public class Skoice extends JavaPlugin {
         getConfig().options().copyDefaults();
         createConfig();
         getLogger().info("Plugin enabled!");
-        if(playerData.getString("token").equals("") || playerData.getString("token") == null){
+        if (playerData.getString("token").equals("") || playerData.getString("token") == null) {
             getLogger().severe(ChatColor.RED + "No bot token, edit the data.yml to add token");
-        } else if(playerData.getString("mainVoiceChannelID").equals("") || playerData.getString("mainVoiceChannelID") == null){
+        } else if (playerData.getString("mainVoiceChannelID").equals("") || playerData.getString("mainVoiceChannelID") == null) {
             getLogger().severe(ChatColor.RED + "No bot mainVoiceChannelID, edit the data.yml to add mainVoiceChannelID");
-        } else if(playerData.getString("categoryID").equals("") || playerData.getString("categoryID")==null){
+        } else if (playerData.getString("categoryID").equals("") || playerData.getString("categoryID") == null) {
             getLogger().severe(ChatColor.RED + "No bot categoryID, edit the data.yml to add categoryID");
-        } else if(playerData.getString("distance")==null) {
+        } else if (playerData.getString("distance") == null) {
             getLogger().severe(ChatColor.RED + "No distance config found, make sure you add the 'distance' from data https://github.com/carlodrift/skoice/blob/dev/src/main/resources/data.yml");
-        }else if(playerData.getString("checkVersion")==null) {
+        } else if (playerData.getString("checkVersion") == null) {
             getLogger().severe(ChatColor.RED + "No checkVersion config found, make sure you add the 'checkVersion' from data https://github.com/carlodrift/skoice/blob/dev/src/main/resources/data.yml");
-        }else{
+        } else {
             //Check Version
-            if(playerData.getBoolean("checkVersion.atStartup")) {
-                getLogger().info(ChatColor.YELLOW+"Checking Version Now!");
+            if (playerData.getBoolean("checkVersion.atStartup")) {
+                getLogger().info(ChatColor.YELLOW + "Checking Version Now!");
                 checkVersion();
             }
             botReady = true;
             main = new Main(this);
         }
-        if(!botReady){
+        if (!botReady) {
             onDisable();
         }
     }
 
-    private void createConfig(){
+    private void createConfig() {
         data = new File(getDataFolder() + File.separator + "data.yml");
-        if(!data.exists()){
+        if (!data.exists()) {
             getLogger().info(ChatColor.LIGHT_PURPLE + "Creating file data.yml");
             this.saveResource("data.yml", false);
         }
         playerData = new YamlConfiguration();
         try {
             playerData.load(data);
-        } catch (IOException | InvalidConfigurationException e){
+        } catch (IOException | InvalidConfigurationException e) {
             e.printStackTrace();
         }
     }
-    public void checkVersion(){
-            try {
-                Skoice nsk = this;
-                String skoiceFileVersion = "v" + nsk.getDescription().getVersion();
 
-                BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(new URL("https://raw.githubusercontent.com/carlodrift/skoice/main/version").openStream()));
-                String spigotVersion = bufferedReader.readLine();
-                if (!skoiceFileVersion.equals(spigotVersion)) {
-                    getLogger().warning((Object) ChatColor.RED + "You are using an outdated version!");
-                    getLogger().warning("Latest version: " + (Object) ChatColor.GREEN + spigotVersion + (Object) ChatColor.YELLOW + ". You are on version: " + ChatColor.RED + skoiceFileVersion + (Object) ChatColor.YELLOW + ".");
-                    getLogger().warning("Update here: " + (Object) ChatColor.AQUA + "https://www.spigotmc.org/resources/skoice-proximity-voice-chat.82861/");
-                }
-                //getLogger().info(ChatColor.GREEN+"Looks like your using the latest version!");
+    public void checkVersion() {
+        try {
+            Skoice nsk = this;
+            String skoiceFileVersion = "v" + nsk.getDescription().getVersion();
 
-            } catch (IOException e) {
-                //getLogger().severe("Unable to check for updates. Error: " + e.getMessage());
-//                checkVersion();
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(new URL("https://raw.githubusercontent.com/carlodrift/skoice/main/version").openStream()));
+            String spigotVersion = bufferedReader.readLine();
+            if (!skoiceFileVersion.equals(spigotVersion)) {
+                getLogger().warning((Object) ChatColor.RED + "You are using an outdated version!");
+                getLogger().warning("Latest version: " + (Object) ChatColor.GREEN + spigotVersion + (Object) ChatColor.YELLOW + ". You are on version: " + ChatColor.RED + skoiceFileVersion + (Object) ChatColor.YELLOW + ".");
+                getLogger().warning("Update here: " + (Object) ChatColor.AQUA + "https://www.spigotmc.org/resources/skoice-proximity-voice-chat.82861/");
             }
+            //getLogger().info(ChatColor.GREEN+"Looks like your using the latest version!");
+
+        } catch (IOException e) {
+            //getLogger().severe("Unable to check for updates. Error: " + e.getMessage());
+//                checkVersion();
+        }
 
     }
 
@@ -150,7 +151,8 @@ public class Skoice extends JavaPlugin {
         try {
             executor.invokeAll(Collections.singletonList(() -> {
                 main.shutdown();
-                if (main.jda != null) main.jda.getEventManager().getRegisteredListeners().forEach(listener -> main.jda.getEventManager().unregister(listener));
+                if (main.jda != null)
+                    main.jda.getEventManager().getRegisteredListeners().forEach(listener -> main.jda.getEventManager().unregister(listener));
                 if (main.jda != null) {
                     CompletableFuture<Void> shutdownTask = new CompletableFuture<>();
                     main.jda.addEventListener(new ListenerAdapter() {
@@ -170,7 +172,8 @@ public class Skoice extends JavaPlugin {
 
                 return null;
             }), 15, TimeUnit.SECONDS);
-        }catch(InterruptedException e){}
+        } catch (InterruptedException e) {
+        }
         executor.shutdownNow();
         getLogger().info("Plugin disabled!");
     }

--- a/src/main/java/net/clementraynaud/main/Main.java
+++ b/src/main/java/net/clementraynaud/main/Main.java
@@ -80,8 +80,8 @@ public class Main extends ListenerAdapter implements CommandExecutor, Listener {
 
     public static JDA jda;
     private static Skoice plugin;
-    public HashMap<UUID,String>uuidCodeMap;
-    public HashMap<UUID,String>uuidIdMap;
+    public HashMap<UUID, String> uuidCodeMap;
+    public HashMap<UUID, String> uuidIdMap;
 
     public Main(Skoice plugin) {
         uuidCodeMap = new HashMap<>();
@@ -99,35 +99,35 @@ public class Main extends ListenerAdapter implements CommandExecutor, Listener {
                     .build()
                     .awaitReady();
             plugin.getLogger().info("JDA is running!");
-        }catch (LoginException | InterruptedException e){
-            plugin.getLogger().severe("JDA ERROR: "+ Arrays.toString(e.getStackTrace()));
+        } catch (LoginException | InterruptedException e) {
+            plugin.getLogger().severe("JDA ERROR: " + Arrays.toString(e.getStackTrace()));
         }
         plugin.getCommand("link").setExecutor(this);
         plugin.getCommand("unlink").setExecutor(this);
-        if (jda!=null) {
+        if (jda != null) {
             jda.addEventListener(this);
             Bukkit.getPluginManager().registerEvents(this, plugin);
             Bukkit.getScheduler().runTaskLater(plugin, () ->
-                    Bukkit.getScheduler().runTaskTimerAsynchronously(
-                            plugin,
-                            this::tick,
-                            0,
-                            5
-                    ),
+                            Bukkit.getScheduler().runTaskTimerAsynchronously(
+                                    plugin,
+                                    this::tick,
+                                    0,
+                                    5
+                            ),
                     0
             );
-            if(plugin.playerData.getBoolean("checkVersion.periodically.enabled")){
+            if (plugin.playerData.getBoolean("checkVersion.periodically.enabled")) {
                 Bukkit.getScheduler().runTaskLater(plugin, () ->
-                        Bukkit.getScheduler().runTaskTimerAsynchronously(
-                                plugin,
-                                plugin::checkVersion,
-                                plugin.playerData.getInt("checkVersion.periodically.delay"), // Delay before first run
-                                plugin.playerData.getInt("checkVersion.periodically.delay") // Delay between every run
-                        ),
+                                Bukkit.getScheduler().runTaskTimerAsynchronously(
+                                        plugin,
+                                        plugin::checkVersion,
+                                        plugin.playerData.getInt("checkVersion.periodically.delay"), // Delay before first run
+                                        plugin.playerData.getInt("checkVersion.periodically.delay") // Delay between every run
+                                ),
                         0
                 );
             }
-        }else{
+        } else {
             plugin.onDisable();
             return;
         }
@@ -149,7 +149,7 @@ public class Main extends ListenerAdapter implements CommandExecutor, Listener {
                         networks.add(new Network(channel.getId()));
                     });
         }
-        if(Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null){
+        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
 //            new PlaceHolderAPI(this).register();
         }
     }
@@ -408,7 +408,8 @@ public class Main extends ListenerAdapter implements CommandExecutor, Listener {
     @Override
     public void onGuildVoiceLeave(GuildVoiceLeaveEvent event) {
         checkMutedUser(event.getChannelJoined(), event.getMember());
-        if (event.getChannelLeft().getParent() == null || !event.getChannelLeft().getParent().equals(getCategory())) return;
+        if (event.getChannelLeft().getParent() == null || !event.getChannelLeft().getParent().equals(getCategory()))
+            return;
 
         UUID uuid = getUniqueId(event.getMember());
         if (uuid == null) return;
@@ -488,7 +489,7 @@ public class Main extends ListenerAdapter implements CommandExecutor, Listener {
     }
 
     public static Member getMember(UUID player) {
-        String discordId = plugin.playerData.getString("Data."+player);
+        String discordId = plugin.playerData.getString("Data." + player);
         return discordId != null ? getGuild().getMemberById(discordId) : null;
 //        String discordId = plugin.getAccountLinkManager().getDiscordId(player);
     }
@@ -496,9 +497,9 @@ public class Main extends ListenerAdapter implements CommandExecutor, Listener {
     public static UUID getUniqueId(Member member) {
 //        return plugin.getAccountLinkManager().getUuid(member.getId());
 //        return guild.getMemberById(plugin.playerData.getString("Data."+u));
-        String id = plugin.playerData.getString("Data."+member.getId());
+        String id = plugin.playerData.getString("Data." + member.getId());
 //        return UUID.fromString(plugin.playerData.getString("Data."+member.getId()));
-        return id != null ? UUID.fromString(plugin.playerData.getString("Data."+member.getId())) : null;
+        return id != null ? UUID.fromString(plugin.playerData.getString("Data." + member.getId())) : null;
     }
 
     public static double verticalDistance(Location location1, Location location2) {
@@ -526,52 +527,45 @@ public class Main extends ListenerAdapter implements CommandExecutor, Listener {
     }
 
     @Override
-    public void onGuildMessageReceived(GuildMessageReceivedEvent event){
-        if(event.getAuthor().isBot()||event.isWebhookMessage())return;
+    public void onGuildMessageReceived(GuildMessageReceivedEvent event) {
+        if (event.getAuthor().isBot() || event.isWebhookMessage()) return;
         String[] args = event.getMessage().getContentRaw().split(" ");
-        if(args[0].equalsIgnoreCase("*link")){
-            String saddsa = plugin.playerData.getString("Data."+event.getAuthor().getId());
-            if(saddsa!=null){
+        if (args[0].equalsIgnoreCase("*link")) {
+            String saddsa = plugin.playerData.getString("Data." + event.getAuthor().getId());
+            if (saddsa != null) {
                 event.getChannel().sendMessage("This discord account is already linked to a player!").queue();
                 return;
             }
-            if(uuidIdMap.containsValue(event.getAuthor().getId())){
-                event.getChannel().sendMessage(":x: **|** Error! "+event.getAuthor().getAsMention()+", you already have a code generated!").queue();
+            if (uuidIdMap.containsValue(event.getAuthor().getId())) {
+                event.getChannel().sendMessage(":x: **|** Error! " + event.getAuthor().getAsMention() + ", you already have a code generated!").queue();
                 return;
             }
-            if(args.length!=2){
+            if (args.length != 2) {
                 event.getChannel().sendMessage(":x: **|** Error! You need to specify a player!").queue();
                 return;
             }
             Player target = Bukkit.getPlayer(args[1]);
-            if(target==null){
+            if (target == null) {
                 event.getChannel().sendMessage(":x: **|** Error! The player is not online!").queue();
                 return;
             }
-            String das = plugin.playerData.getString("Data."+target.getUniqueId());
-            if(das!=null){
+            String das = plugin.playerData.getString("Data." + target.getUniqueId());
+            if (das != null) {
                 event.getChannel().sendMessage("This player is already linked to another discord account").queue();
                 return;
             }
-            String randomcode = new Random().nextInt(800000)+200000+"SK"; //6581446AA
-            uuidCodeMap.put(target.getUniqueId(),randomcode);
-            uuidIdMap.put(target.getUniqueId(),event.getAuthor().getId());
+            String randomcode = new Random().nextInt(800000) + 200000 + "SK"; //6581446AA
+            uuidCodeMap.put(target.getUniqueId(), randomcode);
+            uuidIdMap.put(target.getUniqueId(), event.getAuthor().getId());
 
             event.getAuthor().openPrivateChannel().complete().sendMessage("Hey! Your verification has been generated!\n" +
-                    "Use this command in game: ``/link "+randomcode+"``").queue();
-        } else if(args[0].equalsIgnoreCase("*dlink")){
-            // If Member uses `*dlink` command to link another account
-            String playerIDFromData = plugin.playerData.getString("Data."+event.getAuthor().getId());
-            if(playerIDFromData==null){
-                // Member is trying to link another dicord account, even tho they don't have a main link
-                event.getChannel().sendMessage(":x: **|** You don't have a normal link, use `*link` instead");
-            }
+                    "Use this command in game: ``/link " + randomcode + "``").queue();
         }
     }
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label, String[] args) { //  /verify randomcodeSK
-        if(!(sender instanceof Player)){
+        if (!(sender instanceof Player)) {
             sender.sendMessage("§cOnly players can execute this command!");
             return true;
         }
@@ -579,22 +573,22 @@ public class Main extends ListenerAdapter implements CommandExecutor, Listener {
         //if(cmd.getName().equalsIgnoreCase("ping")){
         //    player.sendMessage("Pong!");
         //}
-        if(cmd.getName().equalsIgnoreCase("unlink")){
+        if (cmd.getName().equalsIgnoreCase("unlink")) {
             String getMemberIDfromFile = plugin.playerData.getString("Data." + player.getUniqueId());
-            if(getMemberIDfromFile==null){
+            if (getMemberIDfromFile == null) {
                 player.sendMessage("§cYou are not currently linked!");
                 return true;
             }
-            String diID = plugin.playerData.getString("Data."+player.getUniqueId());
-            plugin.playerData.set("Data."+player.getUniqueId(), null);
-            plugin.playerData.set("Data."+diID, null);
+            String diID = plugin.playerData.getString("Data." + player.getUniqueId());
+            plugin.playerData.set("Data." + player.getUniqueId(), null);
+            plugin.playerData.set("Data." + diID, null);
             try {
                 plugin.playerData.save(plugin.data);
             } catch (IOException e) {
                 e.printStackTrace();
             }
             return true;
-        }else if(cmd.getName().equalsIgnoreCase("link")) {
+        } else if (cmd.getName().equalsIgnoreCase("link")) {
             String dasd = plugin.playerData.getString("Data." + player.getUniqueId());
             if (dasd != null) {
                 player.sendMessage("§cSorry! You are already linked!");
@@ -648,6 +642,7 @@ public class Main extends ListenerAdapter implements CommandExecutor, Listener {
 
     /**
      * Method return type-safe version of Bukkit::getOnlinePlayers
+     *
      * @return {@code ArrayList} containing online players
      */
     public static List<Player> getOnlinePlayers() {

--- a/src/main/java/net/clementraynaud/main/Main.java
+++ b/src/main/java/net/clementraynaud/main/Main.java
@@ -470,7 +470,7 @@ public class Main extends ListenerAdapter implements CommandExecutor, Listener {
     }
 
     public static Guild getGuild() {
-        return getCategory().getGuild();
+        return getLobbyChannel().getGuild();
     }
 
     public static Category getCategory() {

--- a/src/main/resources/data.yml
+++ b/src/main/resources/data.yml
@@ -5,8 +5,7 @@ distance:
   # Maximum distance between players in order to be connected
   verticalStrength: 40
   horizontalStrength: 80
-  # Once a player has joined a network, they can be
-  # strength + falloff blocks away before being disconnected
+  # Once a player has joined a network, they can be strength + falloff blocks away before being disconnected
   falloff: 5
 checkVersion:
   atStartup: true

--- a/src/main/resources/data.yml
+++ b/src/main/resources/data.yml
@@ -12,3 +12,10 @@ checkVersion:
   periodically:
     enabled: true
     delay: 720000
+forcePlayerInChannel:
+  # false: player doesn't need to be in the discord VC
+  # true: player has to be in VC to join
+  force: false
+  # link to discord server | Tells the player to join the discord server
+  #
+  link: ""


### PR DESCRIPTION
/watermode
Okay so basically this would be a mode which can be configured by /op
Herein, the operator can enable/disable whether the proximity chat will work in water/lava.

This would be great as in real life, talking in water/lava is not possible. So why not add it in the proximity to make things fun!
/bluetooth
Okay so basically this would be a mode that can be configured by /op and be enable/disable whether Bluetooth devices work!
This would basically increase the proximity distance of voice chat wherein we can craft a pair of Bluetooth devices with a recipe and keep it in our offhand in inventory. Then we could like proximity voice chat through a whopping distance of 100-200 blocks or so.

Here's the virtual image of the Bluetooth device recipe (for reference):-
[image](https://user-images.githubusercontent.com/72611306/144882142-023fb345-1e11-4659-808a-dae327d84d9d.png)
The basic idea is that the quartz block is the white colour of the device (like airpods)
The spyglass is like the Bluetooth chip in real life (Limited to 1.17+)
Noteblock is the speaker
End Rod is the light (idk but it's nice)

(Note, the /bluetooth should bypass /watermode as the devices are waterproof)